### PR TITLE
Add overload providing IBuilder access

### DIFF
--- a/src/NServiceBus.Extensions.EndpointStarted.AcceptanceTests/When_registering_endpoint_started_callback.cs
+++ b/src/NServiceBus.Extensions.EndpointStarted.AcceptanceTests/When_registering_endpoint_started_callback.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 namespace NServiceBus.Extensions.EndpointStarted.AcceptanceTests
 {
+    [TestFixture]
     public class When_registering_endpoint_started
     {
         private static bool callbackInvoked;

--- a/src/NServiceBus.Extensions.EndpointStarted.AcceptanceTests/When_resolving_dependencies_in_callback.cs
+++ b/src/NServiceBus.Extensions.EndpointStarted.AcceptanceTests/When_resolving_dependencies_in_callback.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading.Tasks;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.Extensions.EndpointStarted.AcceptanceTests.Config;
+using NUnit.Framework;
+
+namespace NServiceBus.Extensions.EndpointStarted.AcceptanceTests;
+
+[TestFixture]
+public class When_resolving_dependencies_in_callback
+{
+    [Test]
+    public async Task Should_resolve_registered_services()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithDependencies>()
+            .Done(c => c.EndpointsStarted)
+            .Run();
+
+        Assert.NotNull(context.ResolvedService);
+    }
+
+    class Context : ScenarioContext
+    {
+        public SingletonService ResolvedService { get; set; }
+    }
+
+    class EndpointWithDependencies : EndpointConfigurationBuilder
+    {
+        public EndpointWithDependencies() => EndpointSetup<DefaultServer>((configuration, r) =>
+        {
+            configuration.RegisterComponents(c =>
+            {
+                c.ConfigureComponent<SingletonService>(DependencyLifecycle.SingleInstance);
+            });
+            configuration.OnEndpointStarted((session, builder) =>
+            {
+                var testContext = r.ScenarioContext as Context;
+                testContext.ResolvedService = builder.Build<SingletonService>();
+                return Task.CompletedTask;
+            });
+        });
+    }
+
+    class SingletonService
+    {
+    }
+}

--- a/src/NServiceBus.Extensions.EndpointStarted.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.Extensions.EndpointStarted.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -5,5 +5,6 @@ namespace NServiceBus
     public static class OnEndpointStartedEndpointConfigurationExtensions
     {
         public static void OnEndpointStarted(this NServiceBus.EndpointConfiguration configuration, System.Func<NServiceBus.IMessageSession, System.Threading.Tasks.Task> onEndpointStarted) { }
+        public static void OnEndpointStarted(this NServiceBus.EndpointConfiguration configuration, System.Func<NServiceBus.IMessageSession, NServiceBus.ObjectBuilder.IBuilder, System.Threading.Tasks.Task> onEndpointStarted) { }
     }
 }

--- a/src/NServiceBus.Extensions.EndpointStarted/EndpointStartupCallback.cs
+++ b/src/NServiceBus.Extensions.EndpointStarted/EndpointStartupCallback.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NServiceBus.Features;
+using NServiceBus.ObjectBuilder;
 
 namespace NServiceBus
 {
@@ -8,23 +9,25 @@ namespace NServiceBus
     {
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var callback = context.Settings.Get<Func<IMessageSession, Task>>(OnEndpointStartedEndpointConfigurationExtensions.NServiceBusExtensionsEndpointStartedSetting);
-            context.RegisterStartupTask(new CallbackStartupTask(callback));
+            var callback = context.Settings.Get<Func<IMessageSession, IBuilder, Task>>(OnEndpointStartedEndpointConfigurationExtensions.NServiceBusExtensionsEndpointStartedSetting);
+            context.RegisterStartupTask(b => new CallbackStartupTask(callback, b));
         }
     }
 
     class CallbackStartupTask : FeatureStartupTask
     {
-        private readonly Func<IMessageSession, Task> _callback;
+        private readonly Func<IMessageSession, IBuilder, Task> _callback;
+        private readonly IBuilder _builder;
 
-        public CallbackStartupTask(Func<IMessageSession,Task> callback)
+        public CallbackStartupTask(Func<IMessageSession, IBuilder, Task> callback, IBuilder builder)
         {
             _callback = callback;
+            _builder = builder;
         }
 
         protected override Task OnStart(IMessageSession session)
         {
-            return _callback(session);
+            return _callback(session, _builder);
         }
 
         protected override Task OnStop(IMessageSession session)

--- a/src/NServiceBus.Extensions.EndpointStarted/OnEndpointStartedEndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Extensions.EndpointStarted/OnEndpointStartedEndpointConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NServiceBus.Configuration.AdvancedExtensibility;
+using NServiceBus.ObjectBuilder;
 
 namespace NServiceBus
 {
@@ -9,6 +10,12 @@ namespace NServiceBus
         internal const string NServiceBusExtensionsEndpointStartedSetting = "NServiceBus.Extensions.EndpointStarted";
 
         public static void OnEndpointStarted(this EndpointConfiguration configuration, Func<IMessageSession, Task> onEndpointStarted)
+        {
+            configuration.OnEndpointStarted((s, _) => onEndpointStarted(s));
+        }
+
+        public static void OnEndpointStarted(this EndpointConfiguration configuration,
+            Func<IMessageSession, IBuilder, Task> onEndpointStarted)
         {
             if (onEndpointStarted == null)
             {


### PR DESCRIPTION
To allow callbacks to resolve dependencies if needed as they currently can with message handlers.